### PR TITLE
Add Oauth Token Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 
 #Mac OSX
 .DS_Store
+config.yml
+lookerpy/apis/config.yml

--- a/lookerpy/apis/connect_to_api.py
+++ b/lookerpy/apis/connect_to_api.py
@@ -1,0 +1,31 @@
+import yaml
+from api_auth_api import ApiAuthApi
+from ..rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = ApiAuthApi()
+
+def fetch_credentials(configuration_yaml, environment):
+    f = open(configuration_yaml)
+    params = yaml.load(f)
+    f.close()
+
+    client_id = params[environment]['client_id']
+    client_secret = params[environment]['client_secret']
+
+    return client_id, client_secret
+
+def connect_to_api():
+    client_id, client_secret = fetch_credentials('config.yml', 'production')
+
+    try:
+        api_response = api_instance.login(client_id=client_id, client_secret=client_secret)
+
+    except ApiException as e:
+        pprint ('Failed to connect to the Looker API: {}'.format(e))
+
+    return api_response.access_token
+
+if __name__ == '__main__':
+    connect_to_api()

--- a/lookerpy/apis/dashboard_api.py
+++ b/lookerpy/apis/dashboard_api.py
@@ -28,6 +28,7 @@ from six import iteritems
 
 from ..configuration import Configuration
 from ..api_client import ApiClient
+from .connect_to_api import connect_to_api as api_connection
 
 
 class DashboardApi(object):
@@ -45,6 +46,10 @@ class DashboardApi(object):
             if not config.api_client:
                 config.api_client = ApiClient()
             self.api_client = config.api_client
+
+        # When instantiating this class, get an access token and store it as an instance variable
+        __access_token = api_connection()
+        self.__access_token = __access_token
 
     def all_dashboards(self, **kwargs):
         """
@@ -424,8 +429,8 @@ class DashboardApi(object):
         header_params['Content-Type'] = self.api_client.\
             select_header_content_type(['application/json'])
 
-        # Authentication setting
-        auth_settings = []
+        # We put the access token on the instance in the header of our request.
+        header_params['Authorization'] = 'token ' + self.__access_token
 
         response = self.api_client.call_api(resource_path, 'GET',
                                             path_params,
@@ -435,7 +440,6 @@ class DashboardApi(object):
                                             post_params=form_params,
                                             files=local_var_files,
                                             response_type='Dashboard',
-                                            auth_settings=auth_settings,
                                             callback=params.get('callback'))
         return response
 

--- a/lookerpy/apis/look_api.py
+++ b/lookerpy/apis/look_api.py
@@ -19,15 +19,12 @@ Copyright 2016 SmartBear Software
 
 from __future__ import absolute_import
 
-import sys
-import os
-import re
-
 # python 2 and python 3 compatibility library
 from six import iteritems
 
 from ..configuration import Configuration
 from ..api_client import ApiClient
+from .connect_to_api import connect_to_api as api_connection
 
 
 class LookApi(object):
@@ -45,6 +42,10 @@ class LookApi(object):
             if not config.api_client:
                 config.api_client = ApiClient()
             self.api_client = config.api_client
+
+        # When instantiating this class, get an access token and store it as an instance variable
+        __access_token = api_connection()
+        self.__access_token = __access_token
 
     def all_looks(self, **kwargs):
         """
@@ -70,24 +71,19 @@ class LookApi(object):
         all_params = ['fields']
         all_params.append('callback')
 
-        params = locals()
-        for key, val in iteritems(params['kwargs']):
-            if key not in all_params:
-                raise TypeError(
-                    "Got an unexpected keyword argument '%s'"
-                    " to method all_looks" % key
-                )
-            params[key] = val
-        del params['kwargs']
+        params = dir(self)
+        print params
 
+        query_params = {}
+        if 'client_id' in params:
+            query_params['client_id'] = self.client_id
+        if 'client_secret' in params:
+            query_params['client_secret'] = self.client_secret
 
+        print query_params
 
         resource_path = '/looks'.replace('{format}', 'json')
         path_params = {}
-
-        query_params = {}
-        if 'fields' in params:
-            query_params['fields'] = params['fields']
 
         header_params = {}
 
@@ -106,8 +102,8 @@ class LookApi(object):
         header_params['Content-Type'] = self.api_client.\
             select_header_content_type(['application/json'])
 
-        # Authentication setting
-        auth_settings = []
+        # We put the access token on the instance in the header of our request.
+        header_params['Authorization'] = 'token ' + self.__access_token
 
         response = self.api_client.call_api(resource_path, 'GET',
                                             path_params,
@@ -116,9 +112,7 @@ class LookApi(object):
                                             body=body_params,
                                             post_params=form_params,
                                             files=local_var_files,
-                                            response_type='list[Look]',
-                                            auth_settings=auth_settings,
-                                            callback=params.get('callback'))
+                                            response_type='list[Look]')
         return response
 
     def create_look_prefetch(self, look_id, **kwargs):
@@ -248,8 +242,10 @@ class LookApi(object):
             path_params['look_id'] = params['look_id']
 
         query_params = {}
-        if 'fields' in params:
-            query_params['fields'] = params['fields']
+        if 'client_id' in params:
+            query_params['client_id'] = params['client_id']
+        if 'client_secret' in params:
+            query_params['client_secret'] = params['client_secret']
 
         header_params = {}
 
@@ -390,6 +386,7 @@ class LookApi(object):
                  returns the request thread.
         """
 
+
         all_params = ['look_id', 'format', 'limit', 'apply_formatting', 'cache', 'image_width', 'image_height', 'generate_drill_links', 'force_production']
         all_params.append('callback')
 
@@ -411,6 +408,7 @@ class LookApi(object):
             raise ValueError("Missing the required parameter `format` when calling `run_look`")
 
         resource_path = '/looks/{look_id}/run/{format}'
+
         path_params = {}
         if 'look_id' in params:
             path_params['look_id'] = params['look_id']
@@ -450,8 +448,8 @@ class LookApi(object):
         header_params['Content-Type'] = self.api_client.\
             select_header_content_type(['application/json'])
 
-        # Authentication setting
-        auth_settings = []
+        # We put the access token on the instance in the header of our request.
+        header_params['Authorization'] = 'token ' + self.__access_token
 
         response = self.api_client.call_api(resource_path, 'GET',
                                             path_params,
@@ -461,6 +459,6 @@ class LookApi(object):
                                             post_params=form_params,
                                             files=local_var_files,
                                             response_type='str',
-                                            auth_settings=auth_settings,
                                             callback=params.get('callback'))
+
         return response

--- a/lookerpy/configuration.py
+++ b/lookerpy/configuration.py
@@ -56,7 +56,7 @@ class Configuration(object):
         Constructor
         """
         # Default Base url
-        self.host = "https://localhost:9999/api/3.0"
+        self.host = "https://looker-stage-vpc.knewton.net:29999/api/3.0"
         # Default api client
         self.api_client = None
         # Temp file folder for downloading files

--- a/lookerpy/configuration.py
+++ b/lookerpy/configuration.py
@@ -56,7 +56,7 @@ class Configuration(object):
         Constructor
         """
         # Default Base url
-        self.host = "https://looker.buffer.com:19999/api/3.0"
+        self.host = "https://localhost:9999/api/3.0"
         # Default api client
         self.api_client = None
         # Temp file folder for downloading files

--- a/lookerpy/configuration.py
+++ b/lookerpy/configuration.py
@@ -21,6 +21,8 @@ Copyright 2016 SmartBear Software
 from __future__ import absolute_import
 import base64
 import urllib3
+import yaml
+import os
 
 try:
     import httplib
@@ -43,6 +45,16 @@ def singleton(cls, *args, **kw):
     return _singleton
 
 
+def _fetch_credentials(configuration_yaml, environment):
+    f = open(configuration_yaml)
+    params = yaml.load(f)
+    f.close()
+
+    client_id = params[environment]['client_id']
+    client_secret = params[environment]['client_secret']
+
+    return client_id, client_secret
+
 @singleton
 class Configuration(object):
     """
@@ -55,8 +67,15 @@ class Configuration(object):
         """
         Constructor
         """
+        self.configuration_yaml = 'config.yml'
+        self.environment = 'production'
+
+        configuration_yaml = self.configuration_yaml
+        environment = self.environment
+
+        self.client_id, self.client_secret = _fetch_credentials(configuration_yaml, environment)
         # Default Base url
-        self.host = "https://looker-stage-vpc.knewton.net:29999/api/3.0"
+        self.host = "https://looker.knewton.net:29999/api/3.0"
         # Default api client
         self.api_client = None
         # Temp file folder for downloading files
@@ -64,7 +83,12 @@ class Configuration(object):
 
         # Authentication Settings
         # dict to store API key(s)
-        self.api_key = {}
+
+        self.api_key = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }
+
         # dict to store API prefix (e.g. Bearer)
         self.api_key_prefix = {}
         # Username for HTTP basic authentication


### PR DESCRIPTION
- Add a 'token' instance variable to the DashboardApi and LookApi objects.
- Populate them with the output of connect_to_api, a method that connects to the API using user's id/secret key stored in a config file.
- Insert this token into the relevant header requests we want to make.